### PR TITLE
remove invalid "instance_class: S1" that was causing dev_appserver.py and appcfg.py to fail

### DIFF
--- a/static_backend.yaml
+++ b/static_backend.yaml
@@ -5,7 +5,6 @@ runtime: python27
 api_version: 1
 threadsafe: true
 
-instance_class: S1
 manual_scaling:
   instances: 1
 


### PR DESCRIPTION
See b/11220815

eobrain@google.com (App Engine SWE)
