### PR TITLE
fix issues 5 and 6

### DIFF
--- a/printenv.py
+++ b/printenv.py
@@ -104,7 +104,8 @@ class MainHandler(webapp2.RequestHandler):
             html_for_modules_method('get_modules'),
             html_for_modules_method('get_versions'),
             html_for_modules_method('get_default_version'),
-            html_for_modules_method('get_num_instances'),
+            # This crashes when automatic scaling is enabled.
+            # html_for_modules_method('get_num_instances'),
             html_for_modules_method('get_hostname'),
         ]
 


### PR DESCRIPTION
This fixes #5 and fixes #6. The mobile-frontend server crashes currently with this error:

```
Traceback (most recent call last):
  File "/Applications/GoogleAppEngineLauncher.app/Contents/Resources/GoogleAppEngine-default.bundle/Contents/Resources/google_appengine/google/appengine/runtime/wsgi.py", line 267, in Handle
    result = handler(dict(self._environ), self._StartResponse)
  File "/Applications/GoogleAppEngineLauncher.app/Contents/Resources/GoogleAppEngine-default.bundle/Contents/Resources/google_appengine/lib/webapp2-2.3/webapp2.py", line 1519, in __call__
    response = self._internal_error(e)
  File "/Applications/GoogleAppEngineLauncher.app/Contents/Resources/GoogleAppEngine-default.bundle/Contents/Resources/google_appengine/lib/webapp2-2.3/webapp2.py", line 1511, in __call__
    rv = self.handle_exception(request, response, e)
  File "/Applications/GoogleAppEngineLauncher.app/Contents/Resources/GoogleAppEngine-default.bundle/Contents/Resources/google_appengine/lib/webapp2-2.3/webapp2.py", line 1505, in __call__
    rv = self.router.dispatch(request, response)
  File "/Applications/GoogleAppEngineLauncher.app/Contents/Resources/GoogleAppEngine-default.bundle/Contents/Resources/google_appengine/lib/webapp2-2.3/webapp2.py", line 1253, in default_dispatcher
    return route.handler_adapter(request, response)
  File "/Applications/GoogleAppEngineLauncher.app/Contents/Resources/GoogleAppEngine-default.bundle/Contents/Resources/google_appengine/lib/webapp2-2.3/webapp2.py", line 1077, in __call__
    return handler.dispatch()
  File "/Applications/GoogleAppEngineLauncher.app/Contents/Resources/GoogleAppEngine-default.bundle/Contents/Resources/google_appengine/lib/webapp2-2.3/webapp2.py", line 547, in dispatch
    return self.handle_exception(e, self.app.debug)
  File "/Applications/GoogleAppEngineLauncher.app/Contents/Resources/GoogleAppEngine-default.bundle/Contents/Resources/google_appengine/lib/webapp2-2.3/webapp2.py", line 545, in dispatch
    return method(*args, **kwargs)
  File "/Users/peterliu/Development/appengine-modules-helloworld-python/printenv.py", line 107, in get
    html_for_modules_method('get_num_instances'),
  File "/Users/peterliu/Development/appengine-modules-helloworld-python/printenv.py", line 73, in html_for_modules_method
    value = method(*args, **kwargs)
  File "/Applications/GoogleAppEngineLauncher.app/Contents/Resources/GoogleAppEngine-default.bundle/Contents/Resources/google_appengine/google/appengine/api/modules/modules.py", line 271, in get_num_instances
    _ResultHook).get_result()
  File "/Applications/GoogleAppEngineLauncher.app/Contents/Resources/GoogleAppEngine-default.bundle/Contents/Resources/google_appengine/google/appengine/api/apiproxy_stub_map.py", line 613, in get_result
    return self.__get_result_hook(self)
  File "/Applications/GoogleAppEngineLauncher.app/Contents/Resources/GoogleAppEngine-default.bundle/Contents/Resources/google_appengine/google/appengine/api/modules/modules.py", line 259, in _ResultHook
    _CheckAsyncResult(rpc, mapped_errors, {})
  File "/Applications/GoogleAppEngineLauncher.app/Contents/Resources/GoogleAppEngine-default.bundle/Contents/Resources/google_appengine/google/appengine/api/modules/modules.py", line 146, in _CheckAsyncResult
    raise mapped_error()
InvalidVersionError
```

The culprit is the call to `html_for_modules_method('get_num_instances')` which seems to work if you change automatic scaling to manual scaling. 
